### PR TITLE
add go specs for artifact manifest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/oras-project/artifacts-spec
+
+go 1.17
+
+require github.com/opencontainers/image-spec v1.0.1
+
+require github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/oras-project/artifacts-spec
 
 go 1.17
 
-require github.com/opencontainers/image-spec v1.0.1
-
-require github.com/opencontainers/go-digest v1.0.0 // indirect
+require github.com/opencontainers/go-digest v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
+github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
-github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
-github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=

--- a/specs-go/v1/descriptor.go
+++ b/specs-go/v1/descriptor.go
@@ -14,22 +14,27 @@
 
 package v1
 
-// Manifest describes an ORAS artifact.
-// This structure provides `application/vnd.oras.artifact.manifest.v1+json` mediatype when marshalled to JSON.
-type Manifest struct {
+import digest "github.com/opencontainers/go-digest"
+
+// Descriptor describes the disposition of targeted content.
+type Descriptor struct {
 	// MediaType is the media type of the object this schema refers to.
-	MediaType string `json:"mediaType"`
+	MediaType string `json:"mediaType,omitempty"`
 
 	// ArtifactType is the artifact type of the object this schema refers to.
+	//
+	// When the descriptor is used for blobs, this property must be empty.
 	ArtifactType string `json:"artifactType"`
 
-	// Blobs is a collection of blobs referenced by this manifest.
-	Blobs []Descriptor `json:"blobs"`
+	// Digest is the digest of the targeted content.
+	Digest digest.Digest `json:"digest"`
 
-	// SubjectManifest is an optional reference to any existing manifest within the repository.
-	// When specified, the artifact is said to be dependent upon the referenced subjectManifest.
-	SubjectManifest Descriptor `json:"subjectManifest"`
+	// Size specifies the size in bytes of the blob.
+	Size int64 `json:"size"`
 
-	// Annotations contains arbitrary metadata for the artifact manifest.
+	// URLs specifies a list of URLs from which this object MAY be downloaded
+	URLs []string `json:"urls,omitempty"`
+
+	// Annotations contains arbitrary metadata relating to the targeted content.
 	Annotations map[string]string `json:"annotations,omitempty"`
 }

--- a/specs-go/v1/manifest.go
+++ b/specs-go/v1/manifest.go
@@ -1,0 +1,36 @@
+// Copyright 2021 ORAS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import v1 "github.com/opencontainers/image-spec/specs-go/v1"
+
+// Manifest describes an ORAS artifact.
+// This structure provides `application/vnd.oras.artifact.manifest.v1+json` mediatype when marshalled to JSON.
+type Manifest struct {
+	// MediaType is the media type of the object this schema refers to.
+	MediaType string `json:"mediaType"`
+
+	// ArtifactType is the artifact type of the object this schema refers to.
+	ArtifactType string `json:"artifactType"`
+
+	// Blobs is a collection of blobs referenced by this manifest.
+	Blobs []v1.Descriptor `json:"blobs"`
+
+	// SubjectManifest is the manifest this artifact is linked to.
+	SubjectManifest v1.Descriptor `json:"subjectManifest"`
+
+	// Annotations contains arbitrary metadata for the artifact manifest.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}

--- a/specs-go/v1/mediatype.go
+++ b/specs-go/v1/mediatype.go
@@ -16,5 +16,5 @@ package v1
 
 const (
 	// MediaTypeArtifactManifest specifies the media type for an ORAS artifact reference type manifest.
-	MediaTypeArtifactManifest = "application/vnd.oras.artifact.manifest.v1+json"
+	MediaTypeArtifactManifest = "application/vnd.cncf.oras.artifact.manifest.v1+json"
 )

--- a/specs-go/v1/mediatype.go
+++ b/specs-go/v1/mediatype.go
@@ -1,0 +1,20 @@
+// Copyright 2021 ORAS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+const (
+	// MediaTypeArtifactManifest specifies the media type for an ORAS artifact reference type manifest.
+	MediaTypeArtifactManifest = "application/vnd.oras.artifact.manifest.v1+json"
+)


### PR DESCRIPTION
This PR adds Go specs for ORAS Artifact manifest. Addresses #15.