### PR TITLE
Fix quick start doc for macOS

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -44,7 +44,7 @@ A quick-start for push, discover, pull
   ```
 - Get a filtered list by `artifactType`
   ```bash
-  curl $REGISTRY/oras/artifacts/v1/net-monitor/manifests/$DIGEST/referrers?artifactType=sbom%2Fexample | jq
+  curl "$REGISTRY/oras/artifacts/v1/net-monitor/manifests/$DIGEST/referrers?artifactType=sbom%2Fexample" | jq
   ```
 - Get a filtered list with `oras discover`
   ```bash
@@ -57,7 +57,7 @@ A quick-start for push, discover, pull
         oras discover  \
           -o json \
           --artifact-type sbom/example \
-          $IMAGE | jq -r .references[0].digest)
+          $IMAGE | jq -r ".references[0].digest")
   ```
 
 ## Further Reading


### PR DESCRIPTION
Signed-off-by: Li Yi <denverdino@gmail.com>

There are some issues for the macOS users.

```
$ curl $REGISTRY/oras/artifacts/v1/net-monitor/manifests/$DIGEST/referrers?artifactType=sbom%2Fexample | jq
zsh: no matches found: localhost:5000/oras/artifacts/v1/net-monitor/manifests/sha256:a0fc570a245b09ed752c42d600ee3bb5b4f77bbd70d8898780b7ab43454530eb/referrers?artifactType=sbom%2Fexample
```

and

```
$ oras pull -a \
    ${REGISTRY}/${REPO}@$( \
      oras discover  \
        -o json \
        --artifact-type sbom/example \
        $IMAGE | jq -r .references[0].digest)

zsh: no matches found: .references[0].digest
Error: localhost:5000/net-monitor@: not found
```

This PR adds some quote to make shell parse the command properly

```
$ curl "$REGISTRY/oras/artifacts/v1/net-monitor/manifests/$DIGEST/referrers?artifactType=sbom%2Fexample" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   209  100   209    0     0   6531      0 --:--:-- --:--:-- --:--:--  6531
{
  "references": [
    {
      "mediaType": "application/vnd.cncf.oras.artifact.manifest.v1+json",
      "artifactType": "sbom/example",
      "digest": "sha256:82d89db16266d13ab7680badfea3dbd91fd8e311c3b4291d9c0d4f9cff86fa50",
      "size": 401
    }
  ]
}

$ oras pull -a \
    ${REGISTRY}/${REPO}@$( \
      oras discover  \
        -o json \
        --artifact-type sbom/example \
        $IMAGE | jq -r ".references[0].digest")
Downloaded 829a244b13d1 sbom.json
Pulled localhost:5000/net-monitor@sha256:82d89db16266d13ab7680badfea3dbd91fd8e311c3b4291d9c0d4f9cff86fa50
Digest: sha256:82d89db16266d13ab7680badfea3dbd91fd8e311c3b4291d9c0d4f9cff86fa50
```