### PR TITLE
Update invalid doc link in quick-start.md

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -70,4 +70,4 @@ A quick-start for push, discover, pull
 [artifact-manifest-spec]:             ./artifact-manifest.md
 [cncf-distribution]:                  https://github.com/oras-project/distribution
 [oras-releases]:                      https://github.com/oras-project/oras/releases
-[referrers-api]:                      ./manifest-referrers-api.md
+[referrers-api]:                      ../manifest-referrers-api.md


### PR DESCRIPTION
Correct doc link to manifest /referrers API