### PR TITLE
Add sorting by artifact creation datetime

### DIFF
--- a/artifact-manifest.md
+++ b/artifact-manifest.md
@@ -15,7 +15,7 @@ The `artifact.manifest` provides an optional collection of `blobs`, an optional 
 - **`mediaType`** *string*
 
   This field contains the `mediaType` of this document, differentiating from [image-manifest][oci-image-manifest-spec] and [image-index][oci-image-index]. The `mediaType` for this manifest type MUST be `application/vnd.cncf.oras.artifact.manifest.v1+json`, where the version WILL change to reflect newer versions.
-   
+
 - **`artifactType`** *string*
 
   The REQUIRED `artifactType` is a unique value, as registered with [iana.org][registering-iana].
@@ -29,7 +29,7 @@ The `artifact.manifest` provides an optional collection of `blobs`, an optional 
     - Each item in the array MUST be an [artifact descriptor][descriptor], and MUST NOT refer to another `manifest` providing dependency closure.
     - The max number of blobs is not defined, but MAY be limited by [distribution-spec][oci-distribution-spec] implementations.
     - An encountered `[descriptors].descriptor.mediaType` that is unknown to the implementation MUST be persisted as a blob.
-    
+
 
 - **`subject`** *descriptor*
 
@@ -40,6 +40,11 @@ The `artifact.manifest` provides an optional collection of `blobs`, an optional 
 
     This OPTIONAL property contains arbitrary metadata for the artifact manifest.
     This OPTIONAL property MUST use the [annotation rules][annotations-rules].
+    This map MAY contain some or all of the pre-defined keys listed below.
+
+    **Pre-Defined Annotation Keys:**
+    This defines a set of keys that have been pre-defined for use by authors of ORAS artifacts.
+    - `org.cncf.oras.artifact.created` date and time on which the artifact was created (string, date-time as defined by [RFC 3339][rfc-3339])
 
 ### Example ORAS Artifact Manifests
 
@@ -62,13 +67,14 @@ Registries MAY treat the lifecycle of a reference type object, such as an SBoM o
 - [Comparing the ORAS Artifact Manifest and OCI Image Manifest][manifest-differences]
 - [Referrers API](./manifest-referrers-api.md) for more information on listing references
 
-[oci-artifacts]:                   https://github.com/opencontainers/artifacts
-[oci-artifact-authors]:            https://github.com/opencontainers/artifacts/blob/master/artifact-authors.md
-[oci-image-manifest-spec]:         https://github.com/opencontainers/image-spec/blob/master/manifest.md
-[oci-image-manifest-spec-layers]:  https://github.com/opencontainers/image-spec/blob/master/manifest.md#image-manifest-property-descriptions
-[oci-image-index]:                 https://github.com/opencontainers/image-spec/blob/master/image-index.md
-[oci-distribution-spec]:           https://github.com/opencontainers/distribution-spec
-[registering-iana]:                https://github.com/opencontainers/artifacts/blob/master/artifact-authors.md#registering-unique-types-with-iana
+[annotations-rules]:               https://github.com/opencontainers/image-spec/blob/main/annotations.md#rules
 [descriptor]:                      ./descriptor.md
 [manifest-differences]:            ./README.md#comparing-the-oras-artifact-manifest-and-oci-image-manifest
-[annotations-rules]:               https://github.com/opencontainers/image-spec/blob/main/annotations.md#rules
+[oci-artifact-authors]:            https://github.com/opencontainers/artifacts/blob/master/artifact-authors.md
+[oci-artifacts]:                   https://github.com/opencontainers/artifacts
+[oci-distribution-spec]:           https://github.com/opencontainers/distribution-spec
+[oci-image-index]:                 https://github.com/opencontainers/image-spec/blob/master/image-index.md
+[oci-image-manifest-spec-layers]:  https://github.com/opencontainers/image-spec/blob/master/manifest.md#image-manifest-property-descriptions
+[oci-image-manifest-spec]:         https://github.com/opencontainers/image-spec/blob/master/manifest.md
+[registering-iana]:                https://github.com/opencontainers/artifacts/blob/master/artifact-authors.md#registering-unique-types-with-iana
+[rfc-3339]:                        https://tools.ietf.org/html/rfc3339#section-5.6

--- a/manifest-referrers-api.md
+++ b/manifest-referrers-api.md
@@ -44,7 +44,8 @@ ORAS-Api-Version: oras/1.0
 ## Artifact Referrers API results
 
 - Implementations MUST implement [paging](#paging-results).
-- Implementations MAY implement [`artifactType` filtering](#filtering-results).
+- Implementations MUST implement [sorting](#sorting-results)
+- Implementations SHOULD implement [`artifactType` filtering](#filtering-results).
 
 Some artifacts types including signatures, may return multiple signatures of the same `artifactType`.
 For cases where multiple artifacts are returned to the client, it may be necessary to pull each artifact's manifest in order to determine whether or not the full artifact is needed.
@@ -111,8 +112,8 @@ GET /v2/{repository}/_oras/artifacts/referrers?digest={digest}&n=<integer>
 GET /v2/{repository}/_oras/artifacts/referrers?digest=sha256:3c3a4604a545cdc127456d94e421cd355bca5b528f4a9c1905b15da2eb4a4c6b&n=10
 ```
 
-The above specifies that a referrers response should be returned limiting the number of results to `n`. There is no
-ordering imposed on the resulting collection. The response to such a request would look as follows:
+The above specifies that a referrers response should be returned limiting the number of results to `n`.
+The response to such a request would look as follows:
 
 ```json
 200 OK
@@ -156,6 +157,13 @@ The value of the header would be:
 ```
 
 Please see [RFC5988][rfc5988] for details.
+
+### Sorting Results
+The `/referrers` API MUST allow for artifacts to be sorted by the date and time in which they were created, which SHOULD be included in the artifact manifest's list of `annotations`.
+The artifact's creation time MUST be the value of the `org.cncf.oras.artifact.created` annotation, as specified in the [artifact-manifest spec][artifact-manifest-spec].
+The results of the `/referrers` API MUST list artifacts that were created more recently first.
+Artifacts that do not have the `org.cncf.oras.artifact.created` annotation MUST appear after those with creation times specified in the list of results.
+There is no specified ordering for artifacts that do not include the creation time in their list of `annotations`.
 
 ### Filtering Results
 


### PR DESCRIPTION
I've been hearing feedback about issues with
returning an unordered list of references for
use cases that may have a high number of artifacts.
Scan results or short-lived signatures are two examples
of this. In most cases, the artifact which was created
the most recently is usually the more important one.
This is an initial attempt at specifying how that might
look like.

Would love feedback about:
* Sorting mechanism. In talking with @SteveLasker and others, the creation time seems like the right field to sort by. Using the annotation instead of the time the artifact was pushed allows for an image with its related artifacts to be copied between registries while keeping a consistent order.
* I'm suggesting that artifacts without the `created` annotation be sorted last in the list of results. 
* If registries are expected to sort based on this field, should we add it to the result descriptor items? In order to sort by this field, registries will have to store it, so it seems rather trivial to include it in the response list from the `/referrers` api.