### PR TITLE
Update referrers to _oras/artifacts/referrers

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -61,7 +61,7 @@ A quick-start for push, discover, pull
         oras discover  \
           -o json \
           --artifact-type sbom/example \
-          $IMAGE | jq -r ".references[0].digest")
+          $IMAGE | jq -r ".referrers[0].digest")
   ```
 
 ## Further Reading

--- a/manifest-referrers-api.md
+++ b/manifest-referrers-api.md
@@ -3,7 +3,7 @@
 [Artifact-manifest](./artifact-manifest.md) provides the ability to reference artifacts to existing artifacts.
 Reference artifacts include signatures, SBoMs and many other types.
 Artifacts that reference other artifacts SHOULD NOT be tagged, as they are considered enhancements to the artifacts they reference.
-To discover referenced artifacts a manifest `referrers/` API is provided.
+To discover referenced artifacts a `referrers/` extension API is provided.
 An artifact client would parse the returned [artifact descriptors][descriptor], determining which `artifact.manifest` they will pull and process.
 
 The `referrers/` API returns all artifacts that have a `subject` to given manifest digest.
@@ -13,25 +13,33 @@ Artifact references are defined in the [artifact-manifest][oras.artifact.manifes
 
 ## API Path
 
-The `referrers/` api is sits alongside the [distribution-spec][oci-distribution-spec] paths avoiding conflict with existing or new distribution spec apis.
+The `referrers/` api are provided on the [distribution-spec][oci-distribution-spec] paths as described below.
 Pathing within the referrers api provides consistent namespace/repo paths, enabling registry operators to implement consistent auth access, using existing tokens for content.
 
 **template:**
 
 ```rest
-GET /oras/artifacts/v1/{repository}/manifests/{digest}/referrers
+GET /v2/{repository}/_oras/artifacts/referrers?digest={digest}
 ```
 
 **expanded example:**
 
 ```rest
-GET /oras/artifacts/v1/net-monitor/manifests/sha256:3c3a4604a545cdc127456d94e421cd355bca5b528f4a9c1905b15da2eb4a4c6b/referrers
+GET /v2/net-monitor/_oras/artifacts/referrers?digest=sha256:3c3a4604a545cdc127456d94e421cd355bca5b528f4a9c1905b15da2eb4a4c6b
 ```
 
 ## Versioning
 
-This spec defines the behavior of the `/oras/artifacts/v1` version. Clients MUST account for version checking as future major versions MAY NOT be compatible.
-Future Minor versions MUST be additive.
+This specification defines the versioning behavior of `_oras/artifacts/referrers` API.
+Implementations SHOULD return `ORAS-Api-Version: oras/1.0`.  Clients MUST account
+for version checking as future major versions MAY NOT be compatible. Future minor
+versions MUST be additive.
+
+```http
+GET /v2/<repository>/_oras/artifacts/referrers?digest={digest}
+...
+ORAS-Api-Version: oras/1.0
+```
 
 ## Artifact Referrers API results
 
@@ -52,6 +60,7 @@ these references even if the given manifest does not exist in the repository. Th
 if there are no artifacts referencing the given manifest.
 
 **example result of artifacts that reference the `net-monitor` image:**
+
 ```json
 {
   "references": [
@@ -72,6 +81,7 @@ if there are no artifacts referencing the given manifest.
 ```
 
 **example result for a manifest that has no artifacts referencing it:**
+
 ```json
 {
   "references": []
@@ -83,21 +93,21 @@ if there are no artifacts referencing the given manifest.
 The `/referrers` API MUST provide for paging, returning a list of [artifact descriptors](./descriptor.md).
 Page size can be specified by adding a `n` parameter to the request URL, indicating that the response should be limited to `n` results.
 
-* If specified, servers MAY return up to `n` items from the entire result set.
-* When `n` is not provided, servers MAY return a default number of items, which may be implementation specific.
+- If specified, servers MAY return up to `n` items from the entire result set.
+- When `n` is not provided, servers MAY return a default number of items, which may be implementation specific.
 
 A paginated flow begins as:
 
 **template:**
 
 ```rest
-GET /oras/artifacts/v1/{repository}/manifests/{digest}/referrers?n=<integer>
+GET /v2/{repository}/_oras/artifacts/referrers?digest={digest}&n=<integer>
 ```
 
 **expanded example:**
 
 ```rest
-GET /oras/artifacts/v1/net-monitor/manifests/sha256:3c3a4604a545cdc127456d94e421cd355bca5b528f4a9c1905b15da2eb4a4c6b/referrers?n=10
+GET /v2/{repository}/_oras/artifacts/referrers?digest=sha256:3c3a4604a545cdc127456d94e421cd355bca5b528f4a9c1905b15da2eb4a4c6b&n=10
 ```
 
 The above specifies that a referrers response should be returned limiting the number of results to `n`. There is no
@@ -105,6 +115,7 @@ ordering imposed on the resulting collection. The response to such a request wou
 
 ```json
 200 OK
+ORAS-Api-Version:oras/1.0
 Link: <url>; rel="next"
 
 {
@@ -124,21 +135,25 @@ The above includes up to `n` items from the result set. If there are more items,
 encoded in a [RFC5988][rfc5988] `Link` header, as a "next" relation. Clients SHOULD treat this as an opaque value and not try to
 construct it themselves.
 
-* The presence of the `Link` header communicates to the client that the server has more items. Clients are expected
+- The presence of the `Link` header communicates to the client that the server has more items. Clients are expected
   to follow the link to fetch the next page of items, irrespective of the number of items received in the current
   response.
-* If the header is not present, clients can assume that all items have been received.
+- If the header is not present, clients can assume that all items have been received.
 
-> NOTE: In the request template above, the brackets around the url are required. 
+> NOTE: In the request template above, the brackets around the url are required.
 
 For example, if the url is:
+
 ```
-http://example.com/oras/artifacts/v1/hello-world/manifests/sha256:3c3a4604a545cdc127456d94e421cd355bca5b528f4a9c1905b15da2eb4a4c6b/referrers?n=5&nextToken=abc
+http://example.com/v2/hello-world/_oras/artifacts/referrers?digest=sha256:3c3a4604a545cdc127456d94e421cd355bca5b528f4a9c1905b15da2eb4a4c6b&n=5&nextToken=abc
 ```
+
 The value of the header would be:
+
 ```
-<http://example.com/oras/artifacts/v1/hello-world/manifests/sha256:3c3a4604a545cdc127456d94e421cd355bca5b528f4a9c1905b15da2eb4a4c6b/referrers?n=5&nextToken=abc>; rel="next"`.
+<http://example.com/v2/hello-world/_oras/artifacts/referrers?digest=sha256:3c3a4604a545cdc127456d94e421cd355bca5b528f4a9c1905b15da2eb4a4c6b&n=5&nextToken=abc>; rel="next"`.
 ```
+
 Please see [RFC5988][rfc5988] for details.
 
 ### Filtering Results
@@ -150,14 +165,15 @@ Artifact clients MUST revert to client side filtering to determine which `artifa
 Request referenced artifacts by `artifactType`
 
 **template:**
+
 ```rest
-GET /oras/artifacts/v1/{repository}/manifests/{digest}/referrers?n=10&artifactType={artifactType}
+GET /v2/{repository}/_oras/artifacts/referrers?digest={digest}&n=10&artifactType={artifactType}
 ```
 
 **expanded example:**
 
 ```rest
-GET /oras/artifacts/v1/net-monitor/manifests/sha256:3c3a4604a545cdc127456d94e421cd355bca5b528f4a9c1905b15da2eb4a4c6b/referrers?n=10&artifactType=signature%2Fexample
+GET /v2/net-monitor/_oras/artifacts/referrers?digest=sha256:3c3a4604a545cdc127456d94e421cd355bca5b528f4a9c1905b15da2eb4a4c6b&n=10&artifactType=signature%2Fexample
 ```
 
 ## Further Reading

--- a/manifest-referrers-api.md
+++ b/manifest-referrers-api.md
@@ -3,18 +3,18 @@
 [Artifact-manifest](./artifact-manifest.md) provides the ability to reference artifacts to existing artifacts.
 Reference artifacts include signatures, SBoMs and many other types.
 Artifacts that reference other artifacts SHOULD NOT be tagged, as they are considered enhancements to the artifacts they reference.
-To discover referenced artifacts a `referrers/` extension API is provided.
-An artifact client would parse the returned [artifact descriptors][descriptor], determining which `artifact.manifest` they will pull and process.
+The `referrers` extension API is provided to discover these artifacts.
+An artifact client would parse the returned [artifact descriptors][descriptor], determining which  artifact manifest they will pull and process.
 
-The `referrers/` API returns all artifacts that have a `subject` to given manifest digest.
-Referenced artifact requests are scoped to a repository, ensuring access rights for the repository can be used as authorization for the referenced artifacts.
+The `referrers` API returns all artifacts that have a `subject` of the given manifest digest.
+Reference artifact requests are scoped to a repository, ensuring access rights for the repository can be used as authorization for the referenced artifacts.
 
 Artifact references are defined in the [artifact-manifest][oras.artifact.manifest-spec] spec through the [`subject`][oras.artifact.manifest-spec-manifests] property.
 
 ## API Path
 
-The `referrers/` api are provided on the [distribution-spec][oci-distribution-spec] paths as described below.
-Pathing within the referrers api provides consistent namespace/repo paths, enabling registry operators to implement consistent auth access, using existing tokens for content.
+The `referrers` api are provided on the [distribution-spec][oci-distribution-spec] paths as described below.
+Pathing of the referrers api provides consistent namespace/repository paths, enabling registry operators to implement consistent auth access, using existing tokens for content.
 
 **template:**
 
@@ -55,15 +55,16 @@ In future versioned releases, responses MAY be extended to include a `data` fiel
 
 This paged result MUST return the following elements:
 
-- `references`: A list of [artifact descriptors][descriptor] that reference the given manifest. The list MUST include 
-these references even if the given manifest does not exist in the repository. The list MUST be empty 
+- `referrers`: A list of [artifact descriptors][descriptor] that reference the
+given manifest. The list MUST include these references even if the given
+manifest does not exist in the repository. The list MUST be empty
 if there are no artifacts referencing the given manifest.
 
 **example result of artifacts that reference the `net-monitor` image:**
 
 ```json
 {
-  "references": [
+  "referrers": [
     {
       "digest": "sha256:3c3a4604a545cdc127456d94e421cd355bca5b528f4a9c1905b15da2eb4a4c6b",
       "mediaType": "application/vnd.cncf.oras.artifact.manifest.v1+json",
@@ -84,13 +85,13 @@ if there are no artifacts referencing the given manifest.
 
 ```json
 {
-  "references": []
+  "referrers": []
 }
 ```
 
 ### Paging Results
 
-The `/referrers` API MUST provide for paging, returning a list of [artifact descriptors](./descriptor.md).
+The `referrers` API MUST provide for paging, returning a list of [artifact descriptors](./descriptor.md).
 Page size can be specified by adding a `n` parameter to the request URL, indicating that the response should be limited to `n` results.
 
 - If specified, servers MAY return up to `n` items from the entire result set.
@@ -119,7 +120,7 @@ ORAS-Api-Version:oras/1.0
 Link: <url>; rel="next"
 
 {
-  "references": [
+  "referrers": [
     {
       "digest": "<string>",
       "mediaType": "<string>",
@@ -158,7 +159,7 @@ Please see [RFC5988][rfc5988] for details.
 
 ### Filtering Results
 
-The `/referrers` API MAY provide for filtering of `artifactTypes`.
+The `referrers` API MAY provide for filtering of `artifactTypes`.
 Artifact clients MUST account for implementations that MAY NOT support filtering.
 Artifact clients MUST revert to client side filtering to determine which `artifactTypes` they will process.
 


### PR DESCRIPTION
Signed-off-by: Sajay Antony <sajaya@microsoft.com>

The PR updates the `referrers` Api in alignment with the last OCI call, summarized by @stevvooe here - https://github.com/opencontainers/distribution-spec/pull/111#issuecomment-996162334

- The proposal is to move the Api under /v2 in the form  `/v2/{repository}/_oras/artifacts/referrers` 
- Regarding versioning, the proposal defines a header similar to the reference implementation header of `Docker-Distribution-Api-Version: registry/2.0` 

@vbatts @northtyphoon @mnltejaswini