### PR TITLE
Revert descriptors to blobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ The high-level differences between the `oci.image.manifest` and the `oras.artifa
 
 | OCI Image Manifest | ORAS Artifacts Manifest |
 |-|-|
-| `config` REQUIRED | `config` OPTIONAL as it's just another entry in the `descriptors` collection with a config `mediaType` |
-| `layers` REQUIRED | `descriptors` are OPTIONAL blobs, which were renamed from `layers` to reflect general usage |
-| `layers` ORDINAL | `descriptors` are blobs, defined by the specific artifact spec. For example, Helm utilizes two independent, non-ordinal blobs, while other artifact types like container images may require blobs to be ordinal |
+| `config` REQUIRED | `config` OPTIONAL as it's just another entry in the `blobs` collection with a config `mediaType` |
+| `layers` REQUIRED | `blobs` are OPTIONAL, which were renamed from `layers` to reflect general usage |
+| `layers` ORDINAL | `blobs` are defined by the specific artifact spec. For example, Helm utilizes two independent, non-ordinal blobs, while other artifact types like container images may require blobs to be ordinal |
 | `manifest.config.mediaType` used to uniquely identify artifact types. | `manifest.artifactType` added to lift the workaround for using `manifest.config.mediaType` on a REQUIRED, but not always used `config` property. Decoupling `config.mediaType` from `artifactType` enables artifacts to OPTIONALLY share config schemas. |
 | | `subject` OPTIONAL, enabling an artifact to extend another artifact (SBOM, Signatures, Nydus, Scan Results)
 | | `/referrers` api for discovering referenced artifacts, with the ability to filter by `artifactType` |

--- a/artifact-manifest.md
+++ b/artifact-manifest.md
@@ -10,7 +10,7 @@ This section defines the `application/vnd.cncf.oras.artifact.manifest.v1+json` m
 
 ## ORAS Artifact Manifest Properties
 
-The `artifact.manifest` provides an optional collection of `descriptors`, an optional `subject` reference to the manifest of another artifact and an `artifactType` to differentiate types of artifacts (such as signatures, sboms and security scan results)
+The `artifact.manifest` provides an optional collection of `blobs`, an optional `subject` reference to the manifest of another artifact and an `artifactType` to differentiate types of artifacts (such as signatures, sboms and security scan results)
 
 - **`mediaType`** *string*
 
@@ -23,13 +23,11 @@ The `artifact.manifest` provides an optional collection of `descriptors`, an opt
   Examples include `sbom/example`, `application/vnd.cncf.notary.v2`.
   For details on creating a unique `artifactType`, see [OCI Artifact Authors Guidance][oci-artifact-authors]
 
-- **`descriptors`** *array of objects*
+- **`blobs`** *array of objects*
 
-    An OPTIONAL collection of 0 or more descriptors, representing blobs. The descriptors array is analogous to [oci.image.manifest layers][oci-image-manifest-spec-layers], however unlike [image-manifest][oci-image-manifest-spec], the ordering of descriptors is specific to the artifact type. Some artifacts may choose an overlay of files, while other artifact types may store independent collections of files.
-
+  An OPTIONAL collection of 0 or more blobs. The blobs array is analogous to [oci.image.manifest layers][oci-image-manifest-spec-layers], however unlike [image-manifest][oci-image-manifest-spec], the ordering of blobs is specific to the artifact type. Some artifacts may choose an overlay of files, while other artifact types may store independent collections of files.
     - Each item in the array MUST be an [artifact descriptor][descriptor], and MUST NOT refer to another `manifest` providing dependency closure.
-    - The max number of descriptors is not defined, but MAY be limited by [distribution-spec][oci-distribution-spec] implementations.
-    - Each descriptor must be persisted as a blob. The collection is named descriptors to reserve _future_, versioned extensibility where descriptors MAY contain manifest references.
+    - The max number of blobs is not defined, but MAY be limited by [distribution-spec][oci-distribution-spec] implementations.
     - An encountered `[descriptors].descriptor.mediaType` that is unknown to the implementation MUST be persisted as a blob.
     
 
@@ -52,7 +50,7 @@ The `artifact.manifest` provides an optional collection of `descriptors`, an opt
 
 ## Push Validation
 
-Following the [distribution-spec push api](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#push), all `descriptor` references to blobs *and* the `subject` descriptors SHOULD exist when pushed to a distribution instance.
+Following the [distribution-spec push api](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#push), all blobs *and* the `subject` descriptors SHOULD exist when pushed to a distribution instance.
 
 ## Lifecycle Management
 

--- a/examples/net-monitor-image-nydus-ondemand-loading.json
+++ b/examples/net-monitor-image-nydus-ondemand-loading.json
@@ -1,7 +1,7 @@
 {
   "mediaType": "application/vnd.cncf.oras.artifact.manifest.v1+json",
   "artifactType": "application/vnd.cncf.nydus.v1",
-  "descriptors": [
+  "blobs": [
     {
       "mediaType": "application/vnd.cncf.nydus.bootstrap.v1.tar+gzip",
       "digest": "sha256:f6bb0822fe567c98959bb87aa316a565eb1ae059c46fa8bba65b573b4489b44d",

--- a/examples/net-monitor-image-sbom.json
+++ b/examples/net-monitor-image-sbom.json
@@ -1,7 +1,7 @@
 {
   "mediaType": "application/vnd.cncf.oras.artifact.manifest.v1+json",
   "artifactType": "sbom/example",
-  "descriptors": [
+  "blobs": [
     {
       "mediaType": "application/tar",
       "digest": "sha256:9834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f0",

--- a/examples/net-monitor-image-signature.json
+++ b/examples/net-monitor-image-signature.json
@@ -1,7 +1,7 @@
 {
   "mediaType": "application/vnd.cncf.oras.artifact.manifest.v1+json",
   "artifactType": "application/vnd.cncf.notary.v2",
-  "descriptors": [
+  "blobs": [
     {
       "mediaType": "application/tar",
       "digest": "sha256:9834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f0",

--- a/examples/oci-image-artifact.json
+++ b/examples/oci-image-artifact.json
@@ -1,7 +1,7 @@
 {
   "mediaType": "application/vnd.cncf.oras.artifact.manifest.v1+json",
   "artifactType": "application/vnd.oci.image.manifest.v1+json",
-  "descriptors": [
+  "blobs": [
     {
       "mediaType": "application/vnd.oci.image.config.v1+json",
       "digest": "sha256:e752324f6804d5d0b2c098f84507d095a8fd0031cf06cdb3c7ad1625dcd1b399",

--- a/media/net-monitor-graph.svg
+++ b/media/net-monitor-graph.svg
@@ -349,7 +349,7 @@
            x="830.94885"
            y="175.2995"
            id="tspan75448-7-1"
-           style="font-weight:bold">signature [descriptors]</tspan></text>
+           style="font-weight:bold">signature [blobs]</tspan></text>
       <text
          font-family="Calibri, Calibri_MSFontService, sans-serif"
          font-weight="400"
@@ -490,7 +490,7 @@
            x="712.37683"
            y="140.05261"
            id="tspan75448-7-6"
-           style="font-weight:bold">sbom [descriptors]</tspan></text>
+           style="font-weight:bold">sbom [blobs]</tspan></text>
       <text
          font-family="Calibri, Calibri_MSFontService, sans-serif"
          font-weight="400"
@@ -865,7 +865,7 @@
          x="70.740349"
          y="89.949539"
          id="tspan75448-7"
-         style="font-weight:bold;stroke-width:0.0700043">signature [descriptors]</tspan></text>
+         style="font-weight:bold;stroke-width:0.0700043">signature [blobs]</tspan></text>
     <text
        font-family="Calibri, Calibri_MSFontService, sans-serif"
        font-weight="400"

--- a/media/net-monitor-sbom-signature.svg
+++ b/media/net-monitor-sbom-signature.svg
@@ -379,7 +379,7 @@
              x="830.94885"
              y="175.2995"
              id="tspan75448-7-1"
-             style="font-weight:bold">signature [descriptors]</tspan></text>
+             style="font-weight:bold">signature [blobs]</tspan></text>
         <text
            font-family="Calibri, Calibri_MSFontService, sans-serif"
            font-weight="400"
@@ -518,7 +518,7 @@
              x="712.37683"
              y="140.05261"
              id="tspan75448-7-6"
-             style="font-weight:bold">sbom [descriptors]</tspan></text>
+             style="font-weight:bold">sbom [blobs]</tspan></text>
         <text
            font-family="Calibri, Calibri_MSFontService, sans-serif"
            font-weight="400"

--- a/media/net-monitor-sbom.svg
+++ b/media/net-monitor-sbom.svg
@@ -338,7 +338,7 @@
            x="642.32379"
            y="245.91989"
            id="tspan75448-7"
-           style="font-weight:bold">sbom [descriptors]</tspan></text>
+           style="font-weight:bold">sbom [blobs]</tspan></text>
       <text
          font-family="Calibri, Calibri_MSFontService, sans-serif"
          font-weight="400"

--- a/media/net-monitor-with-sigs-copy.svg
+++ b/media/net-monitor-with-sigs-copy.svg
@@ -840,7 +840,7 @@
            x="830.94885"
            y="175.2995"
            id="tspan75448-7-1"
-           style="font-weight:bold">signature [descriptors]</tspan></text>
+           style="font-weight:bold">signature [blobs]</tspan></text>
       <text
          font-family="Calibri, Calibri_MSFontService, sans-serif"
          font-weight="400"
@@ -981,7 +981,7 @@
            x="712.37683"
            y="140.05261"
            id="tspan75448-7-6"
-           style="font-weight:bold">sbom [descriptors]</tspan></text>
+           style="font-weight:bold">sbom [blobs]</tspan></text>
       <text
          font-family="Calibri, Calibri_MSFontService, sans-serif"
          font-weight="400"
@@ -1356,7 +1356,7 @@
          x="56.411297"
          y="284.70801"
          id="tspan75448-7"
-         style="font-weight:bold;stroke-width:0.0700043">signature [descriptors]</tspan></text>
+         style="font-weight:bold;stroke-width:0.0700043">signature [blobs]</tspan></text>
     <text
        font-family="Calibri, Calibri_MSFontService, sans-serif"
        font-weight="400"
@@ -1580,7 +1580,7 @@
            x="830.94885"
            y="175.2995"
            id="tspan75448-7-1-0"
-           style="font-weight:bold">signature [descriptors]</tspan></text>
+           style="font-weight:bold">signature [blobs]</tspan></text>
       <text
          font-family="Calibri, Calibri_MSFontService, sans-serif"
          font-weight="400"
@@ -1721,7 +1721,7 @@
            x="712.37683"
            y="140.05261"
            id="tspan75448-7-6-8"
-           style="font-weight:bold">sbom [descriptors]</tspan></text>
+           style="font-weight:bold">sbom [blobs]</tspan></text>
       <text
          font-family="Calibri, Calibri_MSFontService, sans-serif"
          font-weight="400"
@@ -2096,7 +2096,7 @@
          x="228.76433"
          y="284.7598"
          id="tspan75448-7-22"
-         style="font-weight:bold;stroke-width:0.0700043">signature [descriptors]</tspan></text>
+         style="font-weight:bold;stroke-width:0.0700043">signature [blobs]</tspan></text>
     <text
        font-family="Calibri, Calibri_MSFontService, sans-serif"
        font-weight="400"

--- a/media/notaryv2-signature.svg
+++ b/media/notaryv2-signature.svg
@@ -396,7 +396,7 @@
            x="642.32379"
            y="245.91989"
            id="tspan75448-7"
-           style="font-weight:bold">signature [descriptors]</tspan></text>
+           style="font-weight:bold">signature [blobs]</tspan></text>
       <text
          font-family="Calibri, Calibri_MSFontService, sans-serif"
          font-weight="400"

--- a/scenarios.md
+++ b/scenarios.md
@@ -81,7 +81,7 @@ The `net-monitor:v1` container image is persisted as an `oci.image.manifest`, wi
 
 ### Notary v2 Signatures
 
-Following the [oras.artifact.manifest][artifact-manifest-spec] spec, a signature is pushed with an `manifest.artifactType`, and a `subject` The signature is persisted in the `[descriptors]` collection as a blob, and a `subject` referencing the `net-monitor:v1` container image (by digest).
+Following the [oras.artifact.manifest][artifact-manifest-spec] spec, a signature is pushed with an `manifest.artifactType`, and a `subject` The signature is persisted in the `[blobs]` collection, and a `subject` referencing the `net-monitor:v1` container image (by digest).
 
 ![Notary v2 signature](./media/notaryv2-signature.svg)
 
@@ -94,7 +94,7 @@ Following the [oras.artifact.manifest][artifact-manifest-spec] spec, a signature
   {
     "mediaType": "application/vnd.cncf.oras.artifact.manifest.v1+json",
     "artifactType": "application/vnd.cncf.notary.v2",
-    "descriptors": [
+    "blobs": [
       {
         "mediaType": "application/tar",
         "digest": "sha256:9834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f0",
@@ -115,7 +115,7 @@ Following the [oras.artifact.manifest][artifact-manifest-spec] spec, a signature
 ### SBoM
 
 The same `net-monitor:v1` container image may have an associated SBoM.
-The SBoM content would be persisted as blobs in one or more `[descriptors]` with a `subject` referencing the `net-monitor:v1` container image (by digest).
+The SBoM content would be persisted as one or more `[blobs]` with a `subject` referencing the `net-monitor:v1` container image (by digest).
 
 ![Sample SBOM](./media/net-monitor-sbom.svg)
 
@@ -126,7 +126,7 @@ The SBoM content would be persisted as blobs in one or more `[descriptors]` with
   {
     "mediaType": "application/vnd.cncf.oras.artifact.manifest.v1+json",
     "artifactType": "sbom/example",
-    "descriptors": [
+    "blobs": [
       {
         "mediaType": "application/tar",
         "digest": "sha256:9834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f0",
@@ -155,7 +155,7 @@ The  `net-monitor:v1` SBoM may also be signed, providing yet another leaf node.
   {
     "mediaType": "application/vnd.cncf.oras.artifact.manifest.v1+json",
     "artifactType": "application/vnd.cncf.notary.v2",
-    "descriptors": [
+    "blobs": [
       {
         "mediaType": "application/tar",
         "digest": "sha256:9834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f0",

--- a/specs-go/v1/manifest.go
+++ b/specs-go/v1/manifest.go
@@ -23,8 +23,8 @@ type Manifest struct {
 	// ArtifactType is the artifact type of the object this schema refers to.
 	ArtifactType string `json:"artifactType"`
 
-	// Descriptors is a collection of blobs referenced by this manifest.
-	Descriptors []Descriptor `json:"descriptors"`
+	// Blobs is a collection of blobs referenced by this manifest.
+	Blobs []Descriptor `json:"blobs"`
 
 	// Subject is an optional reference to any existing manifest within the repository.
 	// When specified, the artifact is said to be dependent upon the referenced subject.


### PR DESCRIPTION
I had hoped to get this change done earlier so we didn't have to cope with breaking changes in data persisted in the registry. 
After more review, and more time, there were just too many places that would would need to be changed from the oras cli and oras-go library to notary and registries that have already implemented the oras artifact manifest. 
So, I'm reluctantly PRing a revert of #75

Signed-off-by: Steve Lasker <stevenlasker@hotmail.com>