### PR TITLE
Add descriptor media type for golang spec

### DIFF
--- a/specs-go/v1/mediatype.go
+++ b/specs-go/v1/mediatype.go
@@ -15,6 +15,9 @@
 package v1
 
 const (
+	// MediaTypeDescriptor specifies the media type for a content descriptor.
+	MediaTypeDescriptor = "application/vnd.cncf.oras.artifact.descriptor.v1+json"
+
 	// MediaTypeArtifactManifest specifies the media type for an ORAS artifact reference type manifest.
 	MediaTypeArtifactManifest = "application/vnd.cncf.oras.artifact.manifest.v1+json"
 )


### PR DESCRIPTION
Add a constant `MediaTypeDescriptor` so that golang developer can reference the media type of the descriptor.

Reference: https://github.com/oras-project/artifacts-spec/blob/main/descriptor.md