### PR TITLE
Allow null values in blobs array

### DIFF
--- a/artifact-manifest.md
+++ b/artifact-manifest.md
@@ -27,7 +27,7 @@ The `artifact.manifest` provides an optional collection of `blobs`, an optional 
 - **`blobs`** *array of objects*
 
   An OPTIONAL collection of 0 or more blobs. The blobs array is analogous to [oci.image.manifest layers][oci-image-manifest-spec-layers], however unlike [image-manifest][oci-image-manifest-spec], the ordering of blobs is specific to the artifact type. Some artifacts may choose an overlay of files, while other artifact types may store independent collections of files.
-    - Each item in the array MUST be an [artifact descriptor][descriptor], and MUST NOT refer to another `manifest` providing dependency closure.
+    - Each item in the array MUST be an [artifact descriptor][descriptor] or `null`, and MUST NOT refer to another `manifest` providing dependency closure.
     - The max number of blobs is not defined, but MAY be limited by [distribution-spec][oci-distribution-spec] implementations.
     - An encountered `[descriptors].descriptor.mediaType` that is unknown to the implementation MUST be persisted as a blob.
 


### PR DESCRIPTION
I have a use case where each element in the _blobs_ array is associated with the corresponding element in the _layers_ array of the referent OCI image. However, a blob may be omitted for any particular layer. Therefore, I would like to modify the description of _blob_ elements to explicitly state that `null`s are allowed.

If this PR is accepted, I will submit a PR against *oras-go* to allow that.

The workaround (if the current PR is not accepted) would be to create a zero-length artifact, just so that I'll have something to stick in the array, and push to the remote. This is doable, but less elegant.